### PR TITLE
Add wrapper_options to input definitions for simple_form 3.1.0

### DIFF
--- a/lib/simple_form_fancy_uploads/attachment_preview_input.rb
+++ b/lib/simple_form_fancy_uploads/attachment_preview_input.rb
@@ -1,6 +1,6 @@
 module SimpleFormFancyUploads
   class AttachmentPreviewInput < SimpleForm::Inputs::FileInput
-    def input
+    def input(wrapper_options)
       out = ''
       if object.send("#{attribute_name}?")
         out << template.link_to(object.send(attribute_name).filename, object.send(attribute_name).url)

--- a/lib/simple_form_fancy_uploads/image_preview_input.rb
+++ b/lib/simple_form_fancy_uploads/image_preview_input.rb
@@ -1,6 +1,6 @@
 module SimpleFormFancyUploads
   class ImagePreviewInput < SimpleForm::Inputs::FileInput
-    def input
+    def input(wrapper_options)
       version = input_html_options.delete(:preview_version)
       use_default_url = options.delete(:use_default_url) || false
 

--- a/simple_form_fancy_uploads.gemspec
+++ b/simple_form_fancy_uploads.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.0.0"
 
-  s.add_dependency "simple_form", "~> 3.0"
+  s.add_dependency "simple_form", "~> 3.1.0"
   s.add_dependency "carrierwave"
 end


### PR DESCRIPTION
Simple form 3.1.0 requires custom input definitions to accept a `wrapper_options` argument. Defining the `input` method without accepting `wrapper_options` is deprecated and will be removed in the next version of simple_form.

See https://github.com/plataformatec/simple_form/pull/997 for more information.