### PR TITLE
Render hidden field for cached image upload value to persist upload

### DIFF
--- a/lib/simple_form_fancy_uploads/image_preview_input.rb
+++ b/lib/simple_form_fancy_uploads/image_preview_input.rb
@@ -8,6 +8,7 @@ module SimpleFormFancyUploads
       if object.send("#{attribute_name}?") || use_default_url
         out << template.image_tag(object.send(attribute_name).tap {|o| break o.send(version) if version}.send('url'))
       end
+      out << @builder.input("#{attribute_name}_cache",as: 'hidden')
       (out << super).html_safe
     end
   end


### PR DESCRIPTION
When image upload field renders image in case of failed validation of the form, we need to output a hidden field with carrierwave cached value to keep previously uploaded file.