### PR TITLE
allow users to set the preview url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ If you need to fallback on Carrierwave's `#default_url` method to show a default
 <% end %>
 ```
 
+If you want, you can pass the `preview_url` to the image on the input_html options. This might be useful when you don't have a model binded to the form.
+
+```
+<%= simple_form_for :user do |f| %>
+  <%= f.input :image, as: :image_preview, input_html: { preview_url: image_url } %>
+<% end %>
+```
+
 ### Dependencies
 
 To get it work, you need:

--- a/lib/simple_form_fancy_uploads/image_preview_input.rb
+++ b/lib/simple_form_fancy_uploads/image_preview_input.rb
@@ -1,15 +1,27 @@
 module SimpleFormFancyUploads
   class ImagePreviewInput < SimpleForm::Inputs::FileInput
     def input(wrapper_options=nil)
-      version = input_html_options.delete(:preview_version)
-      use_default_url = options.delete(:use_default_url) || false
+      merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+      url = preview_url(merged_input_options)
 
       out = ''
-      if object.send("#{attribute_name}?") || use_default_url
-        out << template.image_tag(object.send(attribute_name).tap {|o| break o.send(version) if version}.send('url'))
-      end
-      out << @builder.input("#{attribute_name}_cache",as: 'hidden')
+      out << template.image_tag(url) if url
+      out << @builder.input("#{attribute_name}_cache", as: 'hidden')
       (out << super).html_safe
+    end
+
+    private
+
+    def preview_url(merged_input_options)
+      use_default_url = options.delete(:use_default_url) || false
+      version = merged_input_options.delete(:preview_version)
+
+      if merged_input_options[:preview_url]
+        merged_input_options[:preview_url]
+      elsif object && object.send("#{attribute_name}?") || use_default_url
+        object.send(attribute_name).tap {|o| break o.send(version) if version}.send('url')
+      end
     end
   end
 end


### PR DESCRIPTION
I was using this gem with a form that's not binded to any model (http://stackoverflow.com/questions/5181143/simpleform-without-for-non-model-form) and it was crashing on the call to `object.send("#{attribute_name}?")` because there's no object.

This was the workaround I've found to this problem.
